### PR TITLE
Updated readme to include Homebrew installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ EOF
 fc-cache -f -v
 #Done!
 ```
+
+## Install on OS X
+
+If you use [Homebrew](http://brew.sh), you can tap the `caskroom/fonts`
+keg and install the font using `brew`.
+
+```sh
+$ brew tap caskroom/fonts  # Only required if you haven't tapped the fonts keg
+$ brew cask install font-twitter-emoji-color
+```


### PR DESCRIPTION
Homebrew caskroom/fonts has included the font in their repo in [PR #536](https://github.com/caskroom/homebrew-fonts/pull/536).

This means homebrew users can now follow the installation instructions included in this PR.

Closes issue #1 
