### PR TITLE
windows: Add @yincrash's windows install package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TMP := /dev/shm
 # Where to find scfbuild?
 SCFBUILD := SCFBuild/bin/scfbuild
 
-VERSION := 1.1
+VERSION := 1.2
 FONT_PREFIX := TwitterColorEmoji-SVGinOT
 REGULAR_FONT := build/$(FONT_PREFIX).ttf
 REGULAR_PACKAGE := build/$(FONT_PREFIX)-$(VERSION)
@@ -16,6 +16,8 @@ OSX_FONT := build/$(FONT_PREFIX)-OSX.ttf
 OSX_PACKAGE := build/$(FONT_PREFIX)-OSX-$(VERSION)
 LINUX_PACKAGE := $(FONT_PREFIX)-Linux-$(VERSION)
 DEB_PACKAGE := fonts-twemoji-svginot
+WINDOWS_TOOLS := windows
+WINDOWS_PACKAGE := build/$(FONT_PREFIX)-Win-$(VERSION)
 
 # There are two SVG source directories to keep the assets separate
 # from the additions
@@ -32,12 +34,12 @@ SVG_STAGE_FILES := $(patsubst $(SVG_EXTRA)/%.svg, build/stage/%.svg, $(SVG_STAGE
 SVG_BW_FILES := $(patsubst build/stage/%.svg, build/svg-bw/%.svg, $(SVG_STAGE_FILES))
 SVG_COLOR_FILES := $(patsubst build/stage/%.svg, build/svg-color/%.svg, $(SVG_STAGE_FILES))
 
-.PHONY: all package regular-package linux-package osx-package copy-extra clean
+.PHONY: all package regular-package linux-package osx-package windows-package copy-extra clean
 
 all: $(REGULAR_FONT) $(OSX_FONT)
 
 # Create the operating system specific packages
-package: regular-package linux-package deb-package osx-package
+package: regular-package linux-package deb-package osx-package windows-package
 
 regular-package: $(REGULAR_FONT)
 	rm -f $(REGULAR_PACKAGE).zip
@@ -73,6 +75,16 @@ osx-package: $(OSX_FONT)
 	cp LICENSE* $(OSX_PACKAGE)
 	cp README.md $(OSX_PACKAGE)
 	7z a -tzip -mx=9 $(OSX_PACKAGE).zip ./$(OSX_PACKAGE)
+
+windows-package: $(REGULAR_FONT)
+	rm -f $(WINDOWS_PACKAGE).zip
+	rm -rf $(WINDOWS_PACKAGE)
+	mkdir $(WINDOWS_PACKAGE)
+	cp $(REGULAR_FONT) $(WINDOWS_PACKAGE)
+	cp LICENSE* $(WINDOWS_PACKAGE)
+	cp README.md $(WINDOWS_PACKAGE)
+	cp $(WINDOWS_TOOLS)/* $(WINDOWS_PACKAGE)
+	7z a -tzip -mx=9 $(WINDOWS_PACKAGE).zip ./$(WINDOWS_PACKAGE)
 
 # Build both versions of the fonts
 $(REGULAR_FONT): $(SVG_BW_FILES) $(SVG_COLOR_FILES) copy-extra
@@ -125,3 +137,4 @@ build/svg-color: | build
 
 clean:
 	rm -rf build
+

--- a/README.md
+++ b/README.md
@@ -149,10 +149,41 @@ Chrome will use the fallback black and white emoji.*
 
 ## Install on Windows
 
-The font installs like any other font and can be specifically selected, but
-the system will default to the `Segoe UI Emoji` font.
+There are two install options for Windows. Both SVGinOT versions are available
+from releases: https://github.com/eosrei/twemoji-color-font/releases
 
-It can be manually selected in CSS, but making it the default is still TBD.
+### Standard install
+
+The regular version of the font installs like any other font and can be
+specifically selected, but Windows will default to the `Segoe UI Emoji`
+font for emoji characters. Download:
+https://github.com/eosrei/emojione-color-font/releases/download/v1.3/EmojiOneColor-SVGinOT-1.3.zip
+
+### Replace the default Windows emoji fonts
+
+Windows 7, 8, 10 use emoji from both Segoe UI Symbol and Segoe UI Emoji. We
+need to replace both fonts, but keep the existing symbol characters from
+Segoe UI Symbol.
+
+This package contains an install script that will generate both fonts (or
+in Windows 7, just Segoe UI Symbol) and install them for you. Running the
+install script requires both [Python][16] and pip in the PATH.
+
+1. Download the most recent Python 3 for Windows: https://www.python.org/downloads/windows/
+2. Start the installer, select "Add Python 3.6 to PATH" and finish the install process.
+3. Download Twitter Color Emoji Windows package from releases:
+https://github.com/eosrei/twemoji-color-font/releases/download/v1.2/TwitterColorEmoji-SVGinOT-Win-1.2.zip
+4. Uncompress the file.
+5. Open the new TwitterColorEmoji directory.
+7. Run install.cmd. *Note: This will take some time.*
+8. Install both new fonts when requested.
+9. Done!
+
+[16]:https://www.python.org/downloads/windows/
+
+*Reiterating: Only FireFox supports the SVGinOT color emoji for now. IE and
+Chrome will use the fallback black and white emoji.*
+
 
 ## Building
 Overview:

--- a/windows/.gitattributes
+++ b/windows/.gitattributes
@@ -1,0 +1,1 @@
+*.cmd text eol=crlf

--- a/windows/install.cmd
+++ b/windows/install.cmd
@@ -1,0 +1,123 @@
+@ECHO OFF
+SETLOCAL
+
+SET MS_EMOJI_FONT_PATH="%SystemRoot%\Fonts\seguiemj.ttf"
+SET MS_FONT_PATH="%SystemRoot%\Fonts\seguisym.ttf"
+SET EMOJI_FONT_PATH="%CD%\TwitterColorEmoji-SVGinOT.ttf"
+SET FINAL_EMJ_FONT_PATH_NO_QUOTES=%CD%\Segoe UI Emoji with Twemoji.ttf
+SET FINAL_EMJ_FONT_PATH="%FINAL_EMJ_FONT_PATH_NO_QUOTES%"
+SET FINAL_FONT_PATH_NO_QUOTES=%CD%\Segoe UI Symbol with Twemoji.ttf
+SET FINAL_FONT_PATH="%FINAL_FONT_PATH_NO_QUOTES%"
+
+ECHO Checking if Segoe UI Emoji is installed
+
+REM Windows 8 uses Segoe UI Emoji in addition to Symbol
+REM Windows 7 only uses Segoe UI Symbol
+REM We have to replace _both_ 
+ECHO Checking if Segoe UI Symbol is installed.
+
+IF NOT EXIST %MS_FONT_PATH% (
+    ECHO.
+    ECHO You don't seem to have the Segoe UI Symbol Font installed.
+    ECHO https://support.microsoft.com/en-us/kb/2729094
+    GOTO :ERROR
+)
+
+ECHO Checking if prerequisites are installed.
+
+WHERE python /q || (
+    ECHO.
+    ECHO Python.exe not found, install or add to PATH.
+    ECHO.
+    GOTO :ERROR
+)
+
+WHERE pip.exe /q || (
+    ECHO.
+    ECHO Pip.exe not found, install or add to PATH
+    ECHO.
+    GOTO :ERROR
+)
+
+ECHO Ensuring the latest FontTools is installed.
+
+pip.exe install --upgrade https://github.com/behdad/fonttools/archive/master.zip
+
+WHERE ttx /q || (
+    ECHO.
+    ECHO ttx.exe not found, please add Python's Scripts folder to PATH
+    ECHO.
+    GOTO :ERROR
+)
+
+PUSHD %TEMP%
+IF EXIST %MS_EMOJI_FONT_PATH% (
+    ECHO Creating new Segoe UI Emoji font from Twitter Color Emoji
+    ttx -t "name" -o "emjname.ttx" %MS_EMOJI_FONT_PATH% || GOTO :ERROR
+    ttx -o %FINAL_EMJ_FONT_PATH% -m %EMOJI_FONT_PATH% "emjname.ttx" || GOTO :ERROR
+    DEL "emjname.ttx"
+)
+
+ECHO Creating new Segoe UI Symbol font from Twitter Color Emoji
+REM Merge Segoe UI Symbol into TwitterColorEmoji, this keeps 
+REM TwitterColorEmoji's glyph ids intact for the 'SVG ' table data
+pyftmerge %EMOJI_FONT_PATH% %MS_FONT_PATH%
+ECHO Dumping SVG emojis
+ttx -t "SVG " -o "svg.ttx" %EMOJI_FONT_PATH% || GOTO :ERROR
+ttx -t "name" -o "name.ttx" %MS_FONT_PATH% || GOTO :ERROR
+ECHO Merging in dumped emojis
+ttx -o "almost.ttf" -m "merged.ttf" "name.ttx" || GOTO :ERROR
+DEL "merged.ttf"
+DEL "name.ttx"
+ttx -o %FINAL_FONT_PATH% -m "almost.ttf" "svg.ttx" || GOTO :ERROR
+DEL "almost.ttf"
+DEL "svg.ttx"
+REM Get back to working directory.
+POPD
+
+ECHO.
+ECHO.
+IF EXIST %MS_EMOJI_FONT_PATH% (
+    ECHO The fonts are now saved in
+    ECHO %FINAL_FONT_PATH%
+    ECHO and
+    ECHO %FINAL_EMJ_FONT_PATH%
+    ECHO After installation, the original fonts will still be located at
+    ECHO %MS_FONT_PATH%
+    ECHO and
+    ECHO %MS_EMOJI_FONT_PATH%
+    ECHO They are not overwritten, and can be reinstalled with uninstall.cmd
+) ELSE (
+    ECHO The font is now saved in
+    ECHO %FINAL_FONT_PATH%
+    ECHO After installation, the original font will still be located at
+    ECHO %MS_FONT_PATH%
+    ECHO It is not overwritten, and can be reinstalled with uninstall.cmd
+)
+ECHO To finish installation, the font will be opened for you to install.
+ECHO.
+ECHO If the font is in a network path, copy to a local disk and
+ECHO double click to install.
+ECHO Press the [INSTALL] button in the Font Viewer, then close the viewer.
+CHOICE /m "Would you like to install the fonts now?"
+IF ERRORLEVEL 2 (
+    EXIT /b
+)
+ECHO.
+ECHO Running the font installer for Segoe UI Symbol
+REM The font viewer doesn't like quotes for some reason, but is fine with paths with spaces.
+fontview %FINAL_FONT_PATH_NO_QUOTES%
+if EXIST %MS_EMOJI_FONT_PATH% (
+    ECHO.
+    ECHO Running the font installer for Segoe UI Emoji
+    fontview %FINAL_EMJ_FONT_PATH_NO_QUOTES%
+)
+ECHO.
+ECHO All Done!
+PAUSE
+EXIT /b
+
+:ERROR
+ECHO Installation failed!
+PAUSE
+EXIT /b %ERRORLEVEL%

--- a/windows/uninstall.cmd
+++ b/windows/uninstall.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+SETLOCAL
+
+SET MS_EMOJI_FONT_PATH="%SystemRoot%\Fonts\seguiemj.ttf"
+SET MS_FONT_PATH="%SystemRoot%\Fonts\seguisym.ttf"
+
+IF EXIST %MS_EMOJI_FONT_PATH% (
+    ECHO Pressing [INSTALL] button in the Font Viewer will reinstall
+    ECHO the original Segoe UI Emoji font.
+    fontview %SystemRoot%\Fonts\seguiemj.ttf
+)
+ECHO.
+ECHO Pressing [INSTALL] button in the Font Viewer will reinstall
+ECHO the original Segoe UI Symbol font.
+fontview %SystemRoot%\Fonts\seguisym.ttf
+ECHO.
+ECHO All Done!
+PAUSE


### PR DESCRIPTION
Adds an install process to replace Emoji on Windows.
It merges the Twemoji font with Segoe UI Symbol on the user's machine,
and replaces Segoe UI Emoji as well on Win 8 and 10.

An uninstall script is also included to assist the user in restoring
the original Windows fonts.

README also updated.

Fixes #9