### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ https://github.com/eosrei/twemoji-color-font/releases/download/v12.0.1/TwitterCo
 
 [16]:https://www.python.org/downloads/windows/
 
-*Reiterating: Only FireFox and Edge support the SVGinOT color emoji for now. Chrome will use the
+*Reiterating: Only FireFox and Edge (legacy) support the SVGinOT color emoji for now. Chrome and Edge (Chromium based) will use the
 fallback black and white emoji.*
 
 ## Uninstalling


### PR DESCRIPTION
As of Edge Canary 82.0.422.0, SVG in OT is not supported. There is, so far, no announced details on support being added specifically to Edge separately from the underlying Chromium renderer.

<!--
Thank you for making a pull request!

This project has a clean and consistent git history. Commit messages
must be in the following format to be merged:

tag: Title without period less than 50 characters

Comment body text, if needed, describing what and why wrapped to 72
characters.
-->
