### PR TITLE
build: Fix compatibility with Inkscape 1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq (, $(shell which inkscape))
 	$(error "No inkscape in PATH, it is required for fallback b/w variant.")
 endif
 
-ifeq (0, $(shell inkscape --without-gui 1>&2 2> /dev/null; echo $$?))
+ifeq (0, $(shell inkscape --export-png 1>&2 2> /dev/null; echo $$?))
 	# Inkscape < 1.0
 	INKSCAPE_EXPORT_FLAGS := --without-gui --export-png
 else


### PR DESCRIPTION
Inkscape 1.0.1 re-added support for `--without-gui` but `--export-png` does not seem to work, breaking the builds.

https://gitlab.com/inkscape/inkscape/-/commit/3ca6a4ed08405f2a530a9ed3065f77443f9f7ebe